### PR TITLE
predict mask after nms

### DIFF
--- a/MaskRCNNResnet50.py
+++ b/MaskRCNNResnet50.py
@@ -89,8 +89,13 @@ class MaskRCNNResnet50(FasterRCNN):
         h = self.extractor(x)
         rpn_locs, rpn_scores, rois, roi_indices, anchor =\
             self.rpn(h, img_size, scale)
-        roi_cls_locs, roi_scores, mask = self.head(h, rois, roi_indices)
-        return roi_cls_locs, roi_scores, rois, roi_indices, mask
+        if chainer.config.train:
+            roi_cls_locs, roi_scores, mask = self.head(h, rois, roi_indices)
+            return roi_cls_locs, roi_scores, rois, roi_indices, mask
+        else:
+            roi_cls_locs, roi_scores = self.head(h, rois, roi_indices)
+            return roi_cls_locs, roi_scores, rois, roi_indices
+
 
     def predict(self, imgs):
         prepared_imgs = list()
@@ -110,7 +115,7 @@ class MaskRCNNResnet50(FasterRCNN):
                     chainer.function.no_backprop_mode():
                 img_var = chainer.Variable(self.xp.asarray(img[None]))
                 scale = img_var.shape[3] / size[1]
-                roi_cls_locs, roi_scores, rois, roi_indices, mask = self.__call__(
+                roi_cls_locs, roi_scores, rois, roi_indices = self.__call__(
                     img_var, scale=scale)
             # We are assuming that batch size is 1.
             roi_cls_loc = roi_cls_locs.data
@@ -134,55 +139,38 @@ class MaskRCNNResnet50(FasterRCNN):
             cls_bbox[:, 1::2] = self.xp.clip(cls_bbox[:, 1::2], 0, size[1])
 
             prob = F.softmax(roi_score).data
-            mask = F.sigmoid(mask).data
 
             raw_cls_bbox = cuda.to_cpu(cls_bbox)
             raw_prob = cuda.to_cpu(prob)
-            mask = cuda.to_cpu(mask)
             raw_roi = cuda.to_cpu(roi)
 
-            # roiとcls_bboxを見比べて、maskをroiのサイズにリサイズ -> cls_bboxの部分だけ使うという処理に変更する
-            bbox, label, score, mask, roi = self._suppress(
-                raw_cls_bbox, raw_prob, mask, raw_roi)
+            bbox, label, score, roi = self._suppress(
+                raw_cls_bbox, raw_prob, raw_roi)
 
-            # maskは修正前のboxで予測しているので、その大きさにresizeしたあと、修正後のbboxに貼り付ける
+            # predict only mask based on detected roi
             mask_per_image = list()
-            for i, (b, m, r) in enumerate(zip(bbox, mask, roi)):
-                # 修正前のbox
-                w = r[3] - r[1]
-                h = r[2] - r[0]
-                m = cv2.resize(m, (w, h)) * 255
-                m = m.astype(np.uint8)
-                _, m = cv2.threshold(m, 127, 255, cv2.THRESH_BINARY)
+            if len(label) > 0:
+                with chainer.using_config('train', False), \
+                        chainer.function.no_backprop_mode():
+                    # because we are assuming batch size=1, all elements of roi_indices is zero.
+                    roi_indices = self.xp.zeros(roi.shape[0])
+                    mask = self.head.predict_mask(bbox * scale, roi_indices)
+                mask = F.sigmoid(mask).data
+                mask = cuda.to_cpu(mask)
+                # extract single channel per detected box, with correspong labels
+                # label=0 indicates background, so we should shift with +1
+                mask = mask[:, label+1]
+                mask = np.concatenate(mask, axis=0)
 
-                # ここめっちゃダサいんだけど、場合分けする
-                l = b - r
-                l = l.astype(np.int32)
-                if l[0] < 0:
-                    pad = np.zeros((-l[0], m.shape[1]), dtype=np.uint8)
-                    m = np.concatenate([pad, m], axis=0)
-                else:
-                    m = m[l[0]:, :]
+                # maskをresizeする
+                for i, (b, m) in enumerate(zip(bbox, mask)):
+                    w = b[3] - b[1]
+                    h = b[2] - b[0]
+                    m = cv2.resize(m, (w, h)) * 255
+                    m = m.astype(np.uint8)
+                    _, m = cv2.threshold(m, 127, 255, cv2.THRESH_BINARY)
 
-                if l[1] < 0:
-                    pad = np.zeros((m.shape[0], -l[1]), dtype=np.uint8)
-                    m = np.concatenate([pad, m], axis=1)
-                else:
-                    m = m[:, l[1]:]
-
-                if l[2] < 0:
-                    m = m[:l[2], :]
-                else:
-                    pad = np.zeros((l[2], m.shape[1]), dtype=np.uint8)
-                    m = np.concatenate([m, pad], axis=0)
-
-                if l[3] < 0:
-                    m = m[:, :l[3]]
-                else:
-                    pad = np.zeros((m.shape[0], l[3]), dtype=np.uint8)
-                    m = np.concatenate([m, pad], axis=1)
-
-                mask_per_image.append(m)
+                    mask_per_image.append(m)
             bboxes.append(bbox)
             labels.append(label)
             scores.append(score)
@@ -208,11 +196,10 @@ class MaskRCNNResnet50(FasterRCNN):
 
         return img
 
-    def _suppress(self, raw_cls_bbox, raw_prob, raw_mask, raw_roi):
+    def _suppress(self, raw_cls_bbox, raw_prob, raw_roi):
         bbox = list()
         label = list()
         score = list()
-        roi_mask = list()
         roi = list()
         # skip cls_id = 0 because it is the background class
         # -> maskは0から始まるから、l-1を使う
@@ -228,14 +215,11 @@ class MaskRCNNResnet50(FasterRCNN):
             # The labels are in [0, self.n_class - 2].
             label.append((l - 1) * np.ones((len(keep), )))
             score.append(prob_l[keep])
-            mask_l = raw_mask[mask, l]
-            roi_mask.append(mask_l[keep])
             raw_roi_l = raw_roi[:, l, :][mask]
             roi.append(raw_roi_l[keep])
 
         bbox = np.concatenate(bbox, axis=0).astype(np.float32)
         label = np.concatenate(label, axis=0).astype(np.int32)
         score = np.concatenate(score, axis=0).astype(np.float32)
-        roi_mask = np.concatenate(roi_mask, axis=0)
         roi = np.concatenate(roi, axis=0)
-        return bbox, label, score, roi_mask, roi
+        return bbox, label, score, roi


### PR DESCRIPTION
According to original paper,

`
At test time, the proposal number is 300 for the C4 backbone (as in [34]) and 1000 for FPN (as in [27]). We run the box prediction branch on these proposals, followed by non-maximum suppression [14]. The mask branch is then applied to the highest scoring 100 detection boxes. Al- though this differs from the parallel computation used in training, it speeds up inference and improves accuracy (due to the use of fewer, more accurate RoIs).
`

so change prediction pipeline in two path style.